### PR TITLE
Fix hiding text widget and responsive images on parallax widget

### DIFF
--- a/app/assets/stylesheets/scrivito_section_widgets/parallax_section.css
+++ b/app/assets/stylesheets/scrivito_section_widgets/parallax_section.css
@@ -11,7 +11,6 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: -1;
 }
 
 .scrivito_section_parallax_widget .parallax-image {
@@ -24,6 +23,7 @@
   transform: translate3d(0, 0, 0);
   -webkit-transform: translateX(-50%);
   transform: translateX(-50%);
+  z-index: -1;
 }
 
 .scrivito_section_video_widget video {

--- a/app/helpers/srceset_helper.rb
+++ b/app/helpers/srceset_helper.rb
@@ -1,0 +1,14 @@
+module SrcsetHelper
+
+  def srcset_for(obj)
+    image = obj.try(:binary)
+    return unless image
+
+    [160, 320, 640, 1280, 2560].map do |width|
+      transformed_image = image.transform(width: width)
+      url = scrivito_url(transformed_image)
+
+      "#{url} #{width}w"
+    end.join(", ")
+  end
+end

--- a/app/models/section_parallax_widget.rb
+++ b/app/models/section_parallax_widget.rb
@@ -23,4 +23,8 @@ class SectionParallaxWidget < Widget
     # legacy support for widgets before speed option
     speed.presence || 'medium'
   end
+
+  def column_size(image)
+    self.container.column_size(image)
+  end
 end

--- a/app/views/section_parallax_widget/show.html.erb
+++ b/app/views/section_parallax_widget/show.html.erb
@@ -1,7 +1,12 @@
 <section class="<%= widget.section_class %>" style="<%= widget.section_style %>">
   <div class="parallax-container">
     <% if widget.with_parallax? %>
-      <%= scrivito_image_tag(widget, :background_image, class: "parallax-image parallax-image-#{widget.parallax_speed}", data: { parallax_speed: widget.speed }) %>
+      <%= scrivito_image_tag(widget,
+                             :background_image,
+                             { class: "parallax-image parallax-image-#{widget.parallax_speed}",
+                               srcset: srcset_for(widget.background_image),
+                               sizes: "(max-width: 992px) #{widget.column_size(widget)}%, 100%"},
+                             data: { parallax_speed: widget.speed }) %>
     <% end %>
     <%= scrivito_tag(:div, widget, :section_content, class: 'container') %>
   </div>


### PR DESCRIPTION
Noticed that when you placed a text widget inside of the parallax section widget, the text would be hidden once the workspace was published. After looking in the css for this engine, discovered it was a problem with the z-index on the parallax container. 

Placed z-index: -1 on the parallax image instead of the entire container.

Also added basic scrivito image responsiveness for the background images