### PR TITLE
Allow clicking links in video widget

### DIFF
--- a/app/assets/javascripts/scrivito_section_widgets/video_control.js
+++ b/app/assets/javascripts/scrivito_section_widgets/video_control.js
@@ -4,7 +4,7 @@
   $(function() {
     var videos = $(".video-tag");
 
-    $('body').on('click', '.scrivito_section_video_widget :not(a)', function() {
+    $('body').on('click', '.scrivito_section_video_widget :not(a)', function(event) {
       var video = $(this).find('.parallax-video').get(0);
       event.preventDefault();
       if(video.paused){

--- a/app/assets/javascripts/scrivito_section_widgets/video_control.js
+++ b/app/assets/javascripts/scrivito_section_widgets/video_control.js
@@ -4,7 +4,7 @@
   $(function() {
     var videos = $(".video-tag");
 
-    $('body').on('click', '.scrivito_section_video_widget', function() {
+    $('body').on('click', '.scrivito_section_video_widget :not(a)', function() {
       var video = $(this).find('.parallax-video').get(0);
       event.preventDefault();
       if(video.paused){


### PR DESCRIPTION
scrivito catches clicks in links inside video widget to stop the video. However the current implementation prevents links from being followed when inside the video widget.

This PR fixes that by not letting scrivito hijack clicks in `a` tags.

A better approach would require clicks in a very specific `class` like `.js-scrivito-toggle-video` to stop and play the video. However this wouldn't be backwards compatible.

